### PR TITLE
Minor fixes in AutoencoderSindy and SindyLayer

### DIFF
--- a/vindy/layers/sindy_layer.py
+++ b/vindy/layers/sindy_layer.py
@@ -241,10 +241,11 @@ class SindyLayer(tf.keras.layers.Layer):
         return [self.kernel]
 
     def prune_weights(self, threshold=0.01, training=False):
-        mask = tf.greater(
-            tf.math.abs(self.kernel), threshold * tf.ones_like(self.kernel)
-        )
-        self.kernel = tf.multiply(self.kernel, mask)
+        mask = tf.greater(tf.math.abs(self.kernel), threshold * tf.ones_like(self.kernel, dtype=self.kernel.dtype))
+        mask = tf.cast(mask, dtype=self.kernel.dtype)
+        self.kernel.assign(tf.multiply(self.kernel, mask)) # using this instead of
+        # self.kernel = tf.multiply(self.kernel, mask)
+        # because otherwise ThresholdPruneCallback causes an error
 
     def fill_coefficient_matrix(self, trainable_coeffs):
         """

--- a/vindy/networks/autoencoder_sindy.py
+++ b/vindy/networks/autoencoder_sindy.py
@@ -250,7 +250,7 @@ class AutoencoderSindy(BaseModel):
         build a fully connected encoder with layers of size layer_sizes
         :param x: input to the autoencoder
         """
-        x_input = tf.keras.Input(shape=(x.shape[1]), dtype=self.dtype_)
+        x_input = tf.keras.Input(shape=(x.shape[1],), dtype=self.dtype_)
         z = x_input
         for n_neurons in self.layer_sizes:
             z = tf.keras.layers.Dense(


### PR DESCRIPTION
Updated version to fix some problems which I had when running my test case. I added a comma in the method build_encoder in AutoencoderSindy when passing a shape and slightly modified the prune_weights in SindyLayer to avoid and error message and ensure it could be used by ThresholdPruneCallback correctly during the training.
I hope it can be useful!